### PR TITLE
Add nanp_prefix to MP

### DIFF
--- a/data/countries/MP.json
+++ b/data/countries/MP.json
@@ -37,6 +37,7 @@
       "en",
       "ch"
     ],
+    "nanp_prefix": "1670",
     "national_destination_code_lengths": [
       3
     ],


### PR DESCRIPTION
Source: https://www.countrycodeguide.com/oceania/northern-mariana-islands